### PR TITLE
fix: step calculation for time axis overflows on 32 bit platform

### DIFF
--- a/internal/chart/axis.go
+++ b/internal/chart/axis.go
@@ -536,7 +536,7 @@ func calculateTTicks(space float32, min time.Time, max time.Time, supLine bool) 
 		// #years > #ticks/2 -> use years as ticks
 		inc := numYears/maxTickNum + 1
 		coord = time.Date(min.Year(), time.January, 1, 0, 0, 0, 0, time.Local)
-		step = time.Duration(int(time.Hour) * 24 * 365 * inc)
+		step = time.Hour * 24 * 365 * time.Duration(inc)
 		format = "2006"
 		if min.Month() == time.January && min.Day() <= 7 {
 			addMin = true
@@ -545,7 +545,7 @@ func calculateTTicks(space float32, min time.Time, max time.Time, supLine bool) 
 		// #months > #ticks/2 -> use months as ticks
 		inc := (numDays/30)/maxTickNum + 1
 		coord = time.Date(min.Year(), min.Month(), 1, 0, 0, 0, 0, time.Local)
-		step = time.Duration(int(time.Hour) * 24 * 31 * inc)
+		step = time.Hour * 24 * 31 * time.Duration(inc)
 		format = "01.2006"
 		if min.Day() == 1 {
 			addMin = true
@@ -554,7 +554,7 @@ func calculateTTicks(space float32, min time.Time, max time.Time, supLine bool) 
 		// #days > #ticks/2 -> days as ticks
 		inc := numDays/maxTickNum + 1
 		coord = time.Date(min.Year(), min.Month(), min.Day(), 0, 0, 0, 0, time.Local)
-		step = time.Duration(int(time.Hour) * 24 * inc)
+		step = time.Hour * 24 * time.Duration(inc)
 		format = "02.01.2006"
 		if min.Hour() < 1 {
 			addMin = true
@@ -563,7 +563,7 @@ func calculateTTicks(space float32, min time.Time, max time.Time, supLine bool) 
 		// #hours > #ticks/2 -> hours as ticks
 		inc := int(r.Hours())/maxTickNum + 1
 		coord = time.Date(min.Year(), min.Month(), min.Day(), min.Hour(), 0, 0, 0, time.Local)
-		step = time.Duration(int(time.Hour) * inc)
+		step = time.Hour * time.Duration(inc)
 		format = "15h"
 		if min.Minute() < 5 {
 			addMin = true
@@ -572,7 +572,7 @@ func calculateTTicks(space float32, min time.Time, max time.Time, supLine bool) 
 		// #mins > #ticks/2 -> mins as ticks
 		inc := int(r.Minutes())/maxTickNum + 1
 		coord = time.Date(min.Year(), min.Month(), min.Day(), min.Hour(), min.Minute(), 0, 0, time.Local)
-		step = time.Duration(int(time.Minute) * inc)
+		step = time.Minute * time.Duration(inc)
 		format = "15:04"
 		if min.Second() < 5 {
 			addMin = true
@@ -581,7 +581,7 @@ func calculateTTicks(space float32, min time.Time, max time.Time, supLine bool) 
 		// #secs > #ticks/2 -> secs as ticks
 		inc := int(r.Seconds())/maxTickNum + 1
 		coord = time.Date(min.Year(), min.Month(), min.Day(), min.Hour(), min.Minute(), min.Second(), 0, time.Local)
-		step = time.Duration(int(time.Second) * inc)
+		step = time.Second * time.Duration(inc)
 		format = "15:04:05"
 		if min.Sub(coord).Milliseconds() < 25 {
 			addMin = true
@@ -590,7 +590,7 @@ func calculateTTicks(space float32, min time.Time, max time.Time, supLine bool) 
 		// #msecs as ticks
 		inc := int(r.Milliseconds())/maxTickNum + 1
 		coord = time.Date(min.Year(), min.Month(), min.Day(), min.Hour(), min.Minute(), min.Second(), min.Nanosecond(), time.Local)
-		step = time.Duration(int(time.Millisecond) * inc)
+		step = time.Millisecond * time.Duration(inc)
 		format = "05.000"
 		if min.Sub(coord).Nanoseconds() < 100 {
 			addMin = true


### PR DESCRIPTION
When I am trying to build my Fyne app on Android (e.g. with `fyne package -target android`) I get the following build error:

```
../../pkg/mod/github.com/s-daehling/fyne-charts@v0.0.0-20250929185202-4568d7a1ac8c/internal/chart/axis.go:539:28: constant 3600000000000 overflows int
../../pkg/mod/github.com/s-daehling/fyne-charts@v0.0.0-20250929185202-4568d7a1ac8c/internal/chart/axis.go:548:28: constant 3600000000000 overflows int
../../pkg/mod/github.com/s-daehling/fyne-charts@v0.0.0-20250929185202-4568d7a1ac8c/internal/chart/axis.go:557:28: constant 3600000000000 overflows int
../../pkg/mod/github.com/s-daehling/fyne-charts@v0.0.0-20250929185202-4568d7a1ac8c/internal/chart/axis.go:566:28: constant 3600000000000 overflows int
../../pkg/mod/github.com/s-daehling/fyne-charts@v0.0.0-20250929185202-4568d7a1ac8c/internal/chart/axis.go:575:28: constant 60000000000 overflows int
```

This is one of the lines that breaks:
```go
step = time.Duration(int(time.Hour) * 24 * 365 * inc)
```

This error happens, because int on Android/ARM is int32, not int64. And int32 is too small for time.Hour.

The following MR fixes this issue by type casting the `inc` variable instead, like so:

```
step = time.Hour * 24 * 365 * time.Duration(inc)
``` 
