### PR TITLE
docs: Add example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 # fyne-charts
 
-fyne-charts provides widgets for data visualization for the fyne UI toolkit.
-fyne-charts uses native fyne CanvasObjects like canvas.Line, canvas.Circle or canvas.Rectangle.
+fyne-charts provides widgets for data visualization for the Fyne UI toolkit.
+fyne-charts uses native Fyne CanvasObjects like canvas.Line, canvas.Circle or canvas.Rectangle.
 All objects of the chart widget scale with the widget size.
 Properties like the axis range are determined automatically or can be set by the user.
 
@@ -37,15 +37,66 @@ Following list gives an overview of the widgets and supported series types.
 
 ![example](docs/example.png "Example")
 
+## Demo
+
+A demo of the provided widgets and series can be run with:
+
+```sh
+go run github.com/s-daehling/fyne-charts/cmd
+```
+
+> [!TIP]
+> The demo requires you to have Fyne installed and configured in your system.
+> For more information on how to configure your system for Fyne please see: [Fyne - Getting Started](https://docs.fyne.io/started/).
+
 ## Getting started
 
-Include fyne-charts into your project
+You can include fyne-charts into your Go module with the following command:
 
-``
+```sh
 go get github.com/s-daehling/fyne-charts
-``
+```
 
-A demo of the provided widgets and series can be found in ``cmd/main.go``
+## Example
+
+Here is a brief example that shows how to create a bar chart:
+
+```go
+package main
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/app"
+	"fyne.io/fyne/v2/theme"
+
+	"github.com/s-daehling/fyne-charts/pkg/chart"
+	"github.com/s-daehling/fyne-charts/pkg/data"
+)
+
+func main() {
+	a := app.New()
+	w := a.NewWindow("Example chart")
+
+	c := chart.NewCartesianCategoricalChart()
+	_, err := c.AddBarSeries("Amount", []data.CategoricalDataPoint{{
+		C:   "Alpha",
+		Val: 15,
+	}, {
+		C:   "Bravo",
+		Val: 31,
+	}}, theme.Color(theme.ColorNameSuccess))
+	if err != nil {
+		panic(err)
+	}
+	c.SetTitle("My demo chart")
+
+	w.SetContent(c)
+	w.Resize(fyne.NewSize(485, 300))
+	w.ShowAndRun()
+}
+```
+
+For more examples please also see the demo source code at: ``cmd/main.go``.
 
 ## Documentation
 


### PR DESCRIPTION
I would suggest to add an example to the README. I think that really helps people a lot to get started more quickly.

I would also suggest to show how users can run the demo directly. That way users can see without having to install and code anything all the cool features of the library.